### PR TITLE
[backport humble] Wrapper Fork: Add action CI and README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+---
+name: Build and test
+"on":
+  pull_request:
+  push:
+    branches:
+      - humble-rmw-wrapper
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ros: humble
+            ubuntu: jammy
+    name: ROS 2 ${{ matrix.ros }}
+    container:
+      image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-${{ matrix.ubuntu }}:latest
+    env:
+      ROS_DISTRO: ${{ matrix.ros }}
+      RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
+      RMW_IMPLEMENTATION_WRAPPER: rmw_stats_shim
+      DISABLE_GROUPS_WORKAROUND: 1
+    steps:
+      - uses: actions/checkout@v4
+      - shell: bash
+        run: |
+          apt-get update && apt-get install -y -q --no-install-recommends ros-${{ matrix.ros }}-rmw-cyclonedds-cpp
+      - uses: ros-tooling/action-ros-ci@v0.4
+        with:
+          target-ros2-distro: ${{ matrix.ros }}
+          package-name: rmw_implementation test_rmw_implementation
+      - uses: actions/upload-artifact@v4
+        with:
+          name: colcon-logs-${{ matrix.ros }}
+          path: ros_ws/log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# RMW Implementation Fork for RMW Wrapper
+
+This repository is a fork of https://github.com/ros2/rmw_implementation , maintained to provide an extra feature of a `RMW_IMPLEMENTATION_WRAPPER` shim library that can be loaded in addition to the `RMW_IMPLEMENTATION` (DDS, etc.).
+
+This enables e.g. the https://github.com/ros-tooling/graph-monitor/tree/main/rmw_stats_shim to intercept calls to RMW and provide statistics about every node/subscription/publisher in the system.
+
+
+## Development
+
+1. All live rosdistros are supported
+1. Branches are called `${ROS_DISTRO}-rmw-wrapper`
+2. As few modifications are added here as possible
+3. All changes here are backported to all live distros
+4. Upstream branches are periodically merged in
+
+
+### Updating to latest from upstream
+
+Get sources set up
+
+```bash
+git clone https://github.com/robograph-project/rmw_implementation
+cd rmw_implementation
+git remote add ros2 https://github.com/ros2/rmw_implementation
+```
+
+Merge in latest and open PR
+
+```bash
+git checkout ${ROS_DISTRO}-rmw-wrapper
+git checkout -b ${ROS_DISTRO}-merge-latest
+git fetch ros2
+git merge ros2/${ROS_DISTRO}
+# push that branch and open PR
+```
+
+Perform for every distro.

--- a/rmw_implementation/package.xml
+++ b/rmw_implementation/package.xml
@@ -20,15 +20,12 @@
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <build_depend>rmw</build_depend>
-  <!--
-  Bloom does not support group_depend so entries below duplicate the group rmw_implementation_packages.
-  This ensures that binary packages have support for all of these rmw impl. enabled.
-  -->
-  <build_depend>rmw_connextdds</build_depend>
-  <build_depend>rmw_cyclonedds_cpp</build_depend>
-  <build_depend>rmw_fastrtps_cpp</build_depend>
-  <build_depend>rmw_fastrtps_dynamic_cpp</build_depend>
-  <!-- end of group dependencies added for bloom -->
+
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_connextdds</build_depend>
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_cyclonedds_cpp</build_depend>
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_fastrtps_cpp</build_depend>
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_fastrtps_dynamic_cpp</build_depend>
 
   <depend>rmw_implementation_cmake</depend>
 


### PR DESCRIPTION
Also backport ros2/rmw_implementation#229 to let the rosdep portion of the build work without running into connext